### PR TITLE
Removed forward slash and trailing dot on terminal output

### DIFF
--- a/src/Commands/MakeLayoutCommand.php
+++ b/src/Commands/MakeLayoutCommand.php
@@ -335,7 +335,10 @@ class MakeLayoutCommand extends GeneratorCommand
         }
 
         $files->each(function ($stub, $target) {
-            $this->lines[] = "Created {$target}.";
+            if (Str::startsWith($target, '/')) {
+                $target = Str::substr($target, 1);
+            }
+            $this->lines[] = "Created {$target}";
             file_put_contents(
                 base_path($target),
                 $this->parseTemplateStubContent($stub)


### PR DESCRIPTION
This way, you can click in the terminal to open the created file.