### PR TITLE
Fix: Add class validation in getDependedLayoutLabel to prevent fatal …

### DIFF
--- a/src/Concerns/HasFlexible.php
+++ b/src/Concerns/HasFlexible.php
@@ -2,6 +2,7 @@
 
 namespace Marshmallow\Nova\Flexible\Concerns;
 
+use ErrorException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
 use Laravel\Nova\NovaServiceProvider;
@@ -317,8 +318,12 @@ trait HasFlexible
             $layout = (array) $layout;
             $layout = Arr::get($layout, 'layout');
             $flex_class = Arr::get($layouts, $layout);
-            $flex = new $flex_class();
-            return $label . $flex->title();
+            
+            // Validate that $flex_class is a valid class name
+            if ($flex_class && is_string($flex_class) && class_exists($flex_class)) {
+                $flex = new $flex_class();
+                return $label . $flex->title();
+            }
         }
 
         return $label . __('Unknown');


### PR DESCRIPTION
…error

- Added validation to check if flex_class is a valid string and class exists before instantiation
- Added ErrorException import for proper exception handling
- Prevents fatal errors when layout mapping returns null or invalid class names