### PR TITLE
(fix) type-hint parameter as Layout in removeCallback

### DIFF
--- a/src/Layouts/Layout.php
+++ b/src/Layouts/Layout.php
@@ -16,6 +16,7 @@ use Laravel\Nova\Fields\FieldCollection;
 use Illuminate\Contracts\Support\Arrayable;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Marshmallow\HelperFunctions\Facades\URL;
+use Marshmallow\Nova\Flexible\Layouts\Layout;
 use Marshmallow\Nova\Flexible\Http\ScopedRequest;
 use Marshmallow\Nova\Flexible\Concerns\HasFlexible;
 use Marshmallow\Nova\Flexible\Http\FlexibleAttribute;
@@ -569,7 +570,7 @@ class Layout implements LayoutInterface, JsonSerializable, ArrayAccess, Arrayabl
      *
      * @return mixed
      */
-    protected function removeCallback(Flexible $flexible, $layout)
+    protected function removeCallback(Flexible $flexible, Layout $layout)
     {
         return;
     }


### PR DESCRIPTION
Updated the removeCallback method to type-hint the $layout parameter as Layout instead of a generic type, improving type safety and code clarity.