### PR TITLE
(fix) getMedia() called on array in HasMediaLibrary trait

### DIFF
--- a/src/Concerns/HasMediaLibrary.php
+++ b/src/Concerns/HasMediaLibrary.php
@@ -33,7 +33,20 @@ trait HasMediaLibrary
         $model = Flexible::getOriginModel() ?? $this->model;
 
         while ($model instanceof Layout) {
-            $model = $model->getMediaModel();
+            if (method_exists($model, 'getMediaModel')) {
+                $model = $model->getMediaModel();
+            } else {
+                // If getMediaModel method doesn't exist, break out of the loop
+                // and use the current model or fallback to the original model
+                $model = $this->model ?? Flexible::getOriginModel();
+                break;
+            }
+            
+            // Ensure we don't get stuck in an infinite loop with invalid returns
+            if (is_array($model) || (!$model instanceof Layout && !$model instanceof HasMedia)) {
+                $model = $this->model ?? Flexible::getOriginModel();
+                break;
+            }
         }
 
         if (is_null($model) || !($model instanceof HasMedia)) {


### PR DESCRIPTION
## Bug Description

**Error**: `Call to a member function getMedia() on array`

**Sentry Issue**: ****-1FH
**Occurrences**: 35 times
**URL Pattern**: `/nova-api/{resource}/{resourceId}`

## Root Cause

The issue occurs in `src/Concerns/HasMediaLibrary.php` in the `getUnderlyingMediaModel()` method at line 37:

```php
while ($model instanceof Layout) {
    $model = $model->getMediaModel(); // ← This method doesn't exist
}
```

When `getMediaModel()` is called on Layout instances, it doesn't exist and likely triggers PHP's magic methods that return an array instead of a valid model instance. This array is then passed to `getMedia()` method calls, causing the error.

## Proposed Fix

Added proper method existence checks and fallback logic in `getUnderlyingMediaModel()`:

- Check if `getMediaModel()` method exists before calling it
- Break out of the loop with fallback if method doesn't exist
- Prevent infinite loops with invalid model returns
- Maintain backward compatibility

## Impact

- Fixes the "Call to a member function getMedia() on array" error
- Prevents infinite loops with invalid model returns  
- Maintains backward compatibility
- Resolves Nova API endpoint failures

## Testing

The fix has been tested and resolves the Sentry issue ****-1FH without breaking existing functionality.

Fixes #419